### PR TITLE
Add DATA_DIR environment variable

### DIFF
--- a/backend/render.yaml
+++ b/backend/render.yaml
@@ -16,6 +16,8 @@ services:
         value: true
       - key: XML_IMPORT_INTERVAL
         value: 0 */6 * * *
+      - key: DATA_DIR
+        value: /opt/render/project/src/data
     disk:
       name: data
       mountPath: /opt/render/project/src/data

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -35,7 +35,7 @@ app.use((req, res, next) => {
 });
 
 // Инициализация базы данных
-const dataDir = process.env.NODE_ENV === 'production' ? '/data' : path.join(process.cwd(), 'data');
+const dataDir = process.env.DATA_DIR || path.join(process.cwd(), 'data');
 const propertyModel = new PropertyModel(dataDir);
 app.locals.propertyModel = propertyModel;
 

--- a/backend/src/jobs/importXML.ts
+++ b/backend/src/jobs/importXML.ts
@@ -18,7 +18,7 @@ export class XMLImportJob {
   private xmlParser: XMLParser;
 
   constructor() {
-    const dataDir = path.join(process.cwd(), 'data');
+    const dataDir = process.env.DATA_DIR || path.join(process.cwd(), 'data');
     if (!fs.existsSync(dataDir)) {
       fs.mkdirSync(dataDir, { recursive: true });
     }


### PR DESCRIPTION
## Summary
- make data directory configurable via `DATA_DIR` environment variable
- update backend to read from `process.env.DATA_DIR`
- set `DATA_DIR` in `render.yaml`

## Testing
- `npm run build` *(fails: Cannot find name 'console')*

------
https://chatgpt.com/codex/tasks/task_e_68500733707083218a55dd5651a79910